### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ At a minimum you need to have:
 
 * [Ansible](http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-pip) == 2.0.2.0
 * [Virtualbox](https://www.virtualbox.org/wiki/Downloads) >= 4.3.10
-* [Vagrant](https://releases.hashicorp.com/vagrant/1.8.1/) == 1.8.1
+* [Vagrant](https://releases.hashicorp.com/vagrant/1.8.1/) == 1.8.5
 * [vagrant-bindfs](https://github.com/gael-ian/vagrant-bindfs#installation) >= 0.3.1 (Windows users may skip this)
 * [vagrant-hostmanager](https://github.com/smdahlen/vagrant-hostmanager#installation)
 * [Node.js](http://nodejs.org/) >= 4.5.0


### PR DESCRIPTION
# Addressing Issue #52

Docs states usage of Vagrant == 1.8.1 but Trellis/Vagrant file state:
`Vagrant.require_version '>= 1.8.5'`
So updated doc file! :)
